### PR TITLE
feat: moved interaction logic to its own interface/class

### DIFF
--- a/code/Player/Interactable.cs
+++ b/code/Player/Interactable.cs
@@ -1,0 +1,19 @@
+using Sandbox;
+
+/// <summary>
+/// Interface for interactable objects.
+/// Inherit from this interface to create interactable objects.
+/// </summary>
+public interface IInteractable
+{
+  void Interact( SceneTraceResult tr, GameObject player );
+}
+
+public class Interactable : Component, IInteractable
+{
+  public virtual void Interact( SceneTraceResult hit, GameObject player )
+  {
+    // Default interaction behavior
+    Log.Info( "Interacted with " + player.Name );
+  }
+}

--- a/code/Player/PlayerInteraction.cs
+++ b/code/Player/PlayerInteraction.cs
@@ -16,7 +16,7 @@ public sealed class PlayerInteraction : Component
 	protected override void OnFixedUpdate()
 	{
 
-		Interact(); 
+		Interact();
 
 		// Draw the debug information if the boolean is true
 		if ( DrawDebugInteract )
@@ -45,19 +45,16 @@ public sealed class PlayerInteraction : Component
 		// Check for the "interact" Tag and do some logic associated to it 
 		if ( tr.GameObject != null && tr.GameObject.Tags.Has( InteractTag ) )
 		{
-			var printerLogic = tr.GameObject.Components.Get<PrinterLogic>();
-			if ( printerLogic != null && tr.GameObject.Tags.Has( "Printer" ) && Input.Pressed( "Use" ) && printerLogic.PrinterCurrentMoney > 0 )
+			// When the "Use" key is pressed
+			if ( Input.Pressed( "Use" ) )
 			{
-				var playerStats = GameObject.Components.Get<PlayerStats>();
-				if ( playerStats != null )
+				// Get the IInteractable component from the hit object and call the Interact method
+				try
 				{
-					playerStats.AddMoney( printerLogic.PrinterCurrentMoney );
-					printerLogic.ResetPrinterMoney();
-					Sound.Play( "audio/money.sound" );
-				}
-				else
+					tr.GameObject.Components.Get<IInteractable>()?.Interact( tr, GameObject );
+				}catch ( System.Exception e )
 				{
-					Log.Warning( "PlayerStats component is missing." );
+					Log.Error( e );
 				}
 			}
 			DrawDebug();

--- a/code/Printer/PrinterLogic.cs
+++ b/code/Printer/PrinterLogic.cs
@@ -1,7 +1,7 @@
 using Sandbox;
 using System.Diagnostics;
 
-public sealed class PrinterLogic : Component
+public sealed class PrinterLogic : Component, IInteractable
 {
 	// Define the different types of printers
 	public enum PrinterType { Bronze, Silver, Gold, Diamond };
@@ -31,6 +31,25 @@ public sealed class PrinterLogic : Component
 
 	private TimeSince lastUsed = 0; // Set the timer
 	private PrinterType currentPrinterType; // Store the current printer type
+
+	/// <summary>
+	/// Interact with the printer. This comes from the IInteractable interface inherited from the Interactable class.
+	/// </summary>
+	public void Interact( SceneTraceResult tr, GameObject player )
+	{
+		Log.Info( "Interacting with printer" );
+		if ( PrinterCurrentMoney > 0 )
+		{
+			var playerStats = player.Components.Get<PlayerStats>();
+			Log.Info( playerStats );
+			if ( playerStats != null )
+			{
+				playerStats.AddMoney( PrinterCurrentMoney );
+				ResetPrinterMoney();
+				Sound.Play( "audio/money.sound" );
+			}
+		}
+	}
 
 	protected override void OnFixedUpdate()
 	{


### PR DESCRIPTION
Moved the printer interaction logic away from the `PlayerInteraction` class to its own class that can be inherited from other components. This keeps everything clean and modular.

GameObjects to implement interactivity must have the `Interact` tag and a component that inherits the `IInteractable` interface and implements a `public void Interact( SceneTraceResult tr, GameObject player )` function.