### PR TITLE
feat/command-system-improvements

### DIFF
--- a/Assets/scenes/minimal.scene
+++ b/Assets/scenes/minimal.scene
@@ -75,6 +75,13 @@
       ]
     },
     {
+      "__guid": "014dc5c7-62d1-42fc-ace7-5b83dc337bc1",
+      "Flags": 0,
+      "Name": "Game Controller",
+      "Position": "-61.63499,-460.2009,426.7711",
+      "Enabled": true
+    },
+    {
       "__guid": "7a63f673-6998-43a4-80de-532550116c66",
       "Flags": 0,
       "Name": "Network Manager",

--- a/code/Config/CommandConfig.cs
+++ b/code/Config/CommandConfig.cs
@@ -10,6 +10,7 @@ namespace Commands
     string Name { get; }
     string Description { get; }
     int PermissionLevel { get; }
+    // TODO the command function should also take in the GameObject player parameter to be able to send messages to the player perhaps.
     bool CommandFunction( string[] args );
   }
 

--- a/code/Config/CommandConfig.cs
+++ b/code/Config/CommandConfig.cs
@@ -1,0 +1,156 @@
+using System;
+
+namespace Commands
+{
+  /// <summary>
+  /// Interface for command configuration.
+  /// </summary>
+  public interface ICommandConfig
+  {
+    string Name { get; }
+    string Description { get; }
+    int PermissionLevel { get; }
+    bool CommandFunction( string[] args );
+  }
+
+  /// <summary>
+  /// Represents a command with a name, description, permission level, and a function to execute.
+  /// </summary>
+  public class Command : ICommandConfig
+  {
+      /// <summary>
+      /// Gets the name of the command.
+      /// </summary>
+      public string Name { get; }
+  
+      /// <summary>
+      /// Gets the description of the command.
+      /// </summary>
+      public string Description { get; }
+  
+      /// <summary>
+      /// Gets the permission level required to execute the command. Currently does nothing.
+      /// </summary>
+      public int PermissionLevel { get; } = 0;
+  
+      /// <summary>
+      ///  The function to execute when the command is called.
+      /// </summary>
+      private readonly Func<string[], bool> commandFunction;
+  
+      /// <summary>
+      /// Initializes a new instance of the Command class.
+      /// </summary>
+      /// <param name="name">The name of the command.</param>
+      /// <param name="description">The description of the command.</param>
+      /// <param name="permissionLevel">The permission level required to execute the command.</param>
+      /// <param name="commandFunction">The function to execute when the command is called.</param>
+      /// <exception cref="ArgumentNullException">
+      /// Thrown when <paramref name="name"/>, <paramref name="description"/>, or <paramref name="commandFunction"/> is null.
+      /// </exception>
+      public Command(string name, string description, int permissionLevel, Func<string[], bool> commandFunction)
+      {
+          Name = name.ToLowerInvariant() ?? throw new ArgumentNullException(nameof(name));
+          Description = description ?? throw new ArgumentNullException(nameof(description));
+          PermissionLevel = permissionLevel;
+          this.commandFunction = commandFunction ?? throw new ArgumentNullException( nameof( commandFunction ) );
+      }
+  
+      /// <summary>
+      /// Executes the command function with the provided arguments.
+      /// </summary>
+      /// <param name="args">The arguments to pass to the command function. Can be null.</param>
+      /// <returns>True if the command executed successfully; otherwise, false.</returns>
+      public bool CommandFunction(string[] args = null) => commandFunction(args);
+  }
+
+  /// <summary>
+  /// Command configuration.
+  /// </summary>
+  public class CommandConfig
+  {
+    private readonly Dictionary<string, ICommandConfig> _commands = new();
+
+    public IReadOnlyCollection<ICommandConfig> Commands => _commands.Values;
+    /// <summary>
+    /// Registers a command.
+    /// </summary>
+    /// <param name="command"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    public void RegisterCommand( ICommandConfig command )
+    {
+      if ( command == null )
+        throw new ArgumentNullException( nameof( command ) );
+
+      var commandNameLower = command.Name.ToLowerInvariant();
+      if ( _commands.ContainsKey( commandNameLower ) )
+        throw new InvalidOperationException( $"Command with name \"{commandNameLower}\" already exists." );
+
+      _commands[commandNameLower] = command;
+    }
+
+    public void UnregisterCommand( string commandName )
+    {
+      commandName = commandName.ToLowerInvariant();
+      if ( string.IsNullOrWhiteSpace( commandName ) )
+        throw new ArgumentException( "Command name cannot be null or whitespace.", nameof( commandName ) );
+
+      if ( !_commands.Remove( commandName ) )
+        throw new KeyNotFoundException( $"Command with name \"{commandName}\" does not exist." );
+    }
+
+    public ICommandConfig GetCommand( string commandName )
+    {
+      // Lowercase the command name to make it case-insensitive.
+      commandName = commandName.ToLowerInvariant();
+      if ( string.IsNullOrWhiteSpace( commandName ) )
+        throw new ArgumentException( "Command name cannot be null or whitespace.", nameof( commandName ) );
+
+      if ( _commands.TryGetValue( commandName, out var command ) )
+        return command;
+
+      throw new KeyNotFoundException( $"Command with name {commandName} does not exist." );
+    }
+
+    public string[] GetCommandNames() => _commands.Keys.ToArray();
+
+    public bool ExecuteCommand( string commandName, string[] args )
+    {
+      try
+      {
+        var command = GetCommand( commandName );
+        Log.Info( $"Executing command \"{commandName}\"." );
+        return command.CommandFunction( args );
+      }
+      catch ( Exception e )
+      {
+        Log.Error( $"Failed to execute command \"{commandName}\": {e.Message}" );
+        return false;
+      }
+    }
+  }
+}
+
+public static class ConfigManagerHelper
+{
+  private static readonly Guid ConfigManagerGuid = new Guid( "7c7e467f-11f7-43c7-accf-abc02a3790ea" );
+
+  public static ConfigManager GetConfigManager( Scene scene )
+  {
+    try
+    {
+      var configManager = scene.Directory.FindComponentByGuid( ConfigManagerGuid ) as ConfigManager;
+      if ( configManager is null )
+      {
+        Log.Error( "Config Manager not found" );
+      }
+      return configManager;
+    }
+    catch ( Exception e )
+    {
+      Log.Error( $"Failed to get Config Manager: {e.Message}" );
+      return null;
+    }
+  }
+}

--- a/code/Config/ConfigManager.cs
+++ b/code/Config/ConfigManager.cs
@@ -1,0 +1,21 @@
+using Commands;
+
+public sealed class ConfigManager : Component
+{
+	public CommandConfig Commands { get; } = new();
+
+	protected override void OnStart()
+	{
+		Commands.RegisterCommand(new Command(
+				name: "help",
+				description: "List all available commands",
+				permissionLevel: 0,
+				commandFunction: (args) =>
+				{
+						var commandNames = Commands.GetCommandNames();
+						Log.Info($"Available commands: {string.Join(", ", commandNames)}");
+						return true;
+				}
+		));
+	}
+}

--- a/code/Config/ConfigManager.cs
+++ b/code/Config/ConfigManager.cs
@@ -6,16 +6,6 @@ public sealed class ConfigManager : Component
 
 	protected override void OnStart()
 	{
-		Commands.RegisterCommand(new Command(
-				name: "help",
-				description: "List all available commands",
-				permissionLevel: 0,
-				commandFunction: (args) =>
-				{
-						var commandNames = Commands.GetCommandNames();
-						Log.Info($"Available commands: {string.Join(", ", commandNames)}");
-						return true;
-				}
-		));
+		
 	}
 }

--- a/code/UI/Chat.razor
+++ b/code/UI/Chat.razor
@@ -91,6 +91,20 @@
                 return true;
             }
         ));
+
+        // TODO this should be baked into the command system and updated everytime a new command is registered.
+        // Currently done this was cos I have no idea how to send messages from outside of this file :)
+        ConfigManager.Commands.RegisterCommand(new Command(
+            name: "help",
+            description: "List all available commands",
+            permissionLevel: 0,
+            commandFunction: (args) =>
+            {
+                    var commandNames = ConfigManager.Commands.GetCommandNames();
+                    NewSystemMessage($"Available commands: {string.Join(", ", commandNames)}", true);
+                    return true;
+            }
+		));
     }
 
     protected override void OnUpdate()
@@ -203,7 +217,7 @@
 	}
 
     // Super basic commands for now. Expand later for more.
-    // TODO Move this to a separate class & make it more extensible
+    // TODO Create a function to suggest commands as the user types. Giving arrow keys + tab controls to cycle through suggestions.
     public bool CheckCommand(string message)
     {
         if (ConfigManager is null) return false;

--- a/code/UI/Chat.razor
+++ b/code/UI/Chat.razor
@@ -1,6 +1,7 @@
-﻿@using Sandbox;
+﻿﻿@using Sandbox;
 @using Sandbox.UI;
 @using System;
+@using Commands;
 @inherits PanelComponent
 @implements Component.INetworkListener
 
@@ -12,7 +13,7 @@
         </div>
     }
 	<div class="output">
-		@foreach (var entry in Entries)
+		@foreach (var entry in Messages)
         {
             // Only show the messages from the last 10 seconds, or all if the input box is focused
             @if (entry.timeSinceAdded < 10f || ChatOpen)
@@ -42,16 +43,60 @@
     public record Entry(ulong steamid, string author, string message, RealTimeSince timeSinceAdded)
     {
         public bool IsNew { get; set; } = true;
-        public string timestamp { get; set; } = DateTime.Now.ToString("HH:mm:ss");
+        public string timestamp { get; } = DateTime.Now.ToString("HH:mm:ss");
     }
-    List<Entry> Entries = new();
+    List<Entry> Messages = new();
+
+    // ConfigManager is a helper class that allows us to register commands and other things
+    ConfigManager ConfigManager;
+    protected override void OnStart()
+    {
+        /// Get the ConfigManager from the scene
+        ConfigManager = ConfigManagerHelper.GetConfigManager(Scene);
+        if (ConfigManager is null)
+        {
+            Log.Error( "Config Manager not found" );
+            return;
+        }
+
+        // Register the chat commands
+        ConfigManager.Commands.RegisterCommand(new Command(
+            name: "clear",
+            description: "Clears the chat",
+            permissionLevel: 0,
+            commandFunction: (args) =>
+            {
+                Messages.Clear();
+                NewSystemMessage("Chat has been cleared", true);
+                return true;
+            }
+        ));
+
+        ConfigManager.Commands.RegisterCommand(new Command(
+            name: "lorem",
+            description: "Spams the chat with lorem ipsum X times.",
+            permissionLevel: 0,
+            commandFunction: (args) =>
+            {
+                if (args.Length == 0 || !int.TryParse(args[0], out int count))
+                {
+                    NewSystemMessage("Invalid argument. Usage: lorem <count>", true);
+                    return false;
+                }
+
+                for (int i = 0; i < count; i++)
+                {
+                    NewUserMessage("Lorem ipsum dolor sit amet.", true);
+                }
+                return true;
+            }
+        ));
+    }
 
     protected override void OnUpdate()
     {
         if (InputBox is null)
             return;
-
-        Panel.AcceptsFocus = false;
 
         if ( Input.Pressed( "chat" ) )
         {
@@ -59,13 +104,16 @@
         }
 
         // Clear the "new" flag after 10 seconds. This is to make sure we don't update chat state every frame
-        foreach (var entry in Entries.Where(e => e.IsNew && e.timeSinceAdded > 10.0f))
+        foreach (var entry in Messages.Where(e => e.IsNew && e.timeSinceAdded > 10.0f))
         {
             entry.IsNew = false;
             StateHasChanged();
         }
     }
 
+    /// <summary>
+    /// Opens and closes the Chat UI state.
+    /// </summary>
     void ToggleChat(bool open)
     {
         ChatOpen = open;
@@ -80,6 +128,9 @@
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Called when the user has finished typing a message in the chat
+    /// </summary>
     void ChatFinished()
     {
         ToggleChat(false);
@@ -90,100 +141,85 @@
             return;
 
         if ( CheckCommand(text) == true) return;
-        AddText( text );
+        NewUserMessage( text );
     }
 
+    /// <summary>
+    /// Sends a new message to broadcast to all clients
+    /// </summary>
     [Broadcast]
-    public void AddText( string message )
+    public void SendMessage( string message, bool system = false, bool clientOnly = false)
     {
-        message = message.Truncate( 300 );
+        // Return if it's a client-only message and the caller isn't the local client
+        if (clientOnly && Rpc.Caller != Connection.Local) return;
 
+        // Return if the message is empty
         if (string.IsNullOrWhiteSpace(message))
             return;
 
-        var author = Rpc.Caller.DisplayName;
-        var steamid = Rpc.Caller.SteamId;
 
-		Log.Info($"{author}: {message}");
+        var author = system ? "ℹ️" : Rpc.Caller.DisplayName;
+        var steamid = system ? 0 : Rpc.Caller.SteamId;
 
-        if (Entries.Count > 30)
+        // If there are 30 messages, remove the oldest one
+        if (Messages.Count > 30)
         {
-            Entries.RemoveAt(0);
+            Messages.RemoveAt(0);
         }
-        Entries.Add(new Entry(steamid, author, message, 0.0f));
-		StateHasChanged();
+
+        // Add the message to the chat
+        Messages.Add(new Entry(steamid, author, message, 0.0f));
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Sends a new message from a user to broadcast to all clients
+    /// </summary>
+    public void NewUserMessage( string message, bool clientOnly = false )
+    {
+        SendMessage( message, false, clientOnly );
 	}
 
-    [Broadcast] // todo: only from host/owner
-    public void AddSystemText(string message)
+    /// <summary>
+    /// Sends a new system message to broadcast to all clients
+    /// </summary>
+    public void NewSystemMessage( string message, bool clientOnly = false)
     {
-        message = message.Truncate(300);
-
-        if (string.IsNullOrWhiteSpace(message))
-            return;
-
-        Entries.Add(new Entry(0, "ℹ️", message, 0.0f));
-        StateHasChanged();
+        SendMessage( message, true, clientOnly );
     }
 
 	void Component.INetworkListener.OnConnected( Connection channel )
 	{
 		if ( IsProxy ) return;
 
-		AddSystemText( $"{channel.DisplayName} has joined the game" );
+		NewSystemMessage( $"{channel.DisplayName} has joined the game" );
 	}
 
 	void Component.INetworkListener.OnDisconnected( Connection channel )
 	{
 		if ( IsProxy ) return;
 
-		AddSystemText( $"{channel.DisplayName} has left the game" );
+		NewSystemMessage( $"{channel.DisplayName} has left the game" );
 	}
 
     // Super basic commands for now. Expand later for more.
     // TODO Move this to a separate class & make it more extensible
     public bool CheckCommand(string message)
     {
+        if (ConfigManager is null) return false;
         if (message.StartsWith("/"))
         {
             var parts = message.Split(" ");
             var command = parts[0].Substring(1).ToLower();
             var args = parts.Skip(1).ToArray();
-
-            switch (command)
+            try
             {
-                case "help":
-                    AddSystemText("Available commands: /help, /clear, /lorem [count]");
-                    return true;
-                case "clear":
-                    Entries.Clear();
-                    AddSystemText("Chat has been cleared");
-                    return true;
-                case "lorem":
-                    // Loop X times for args 1
-                    var count = 1;
-                    if (args.Length > 0)
-                    {
-                        if (!int.TryParse(args[0], out count))
-                        {
-                            AddText("Invalid argument: " + args[0]);
-                            return true;
-                        }
-                    }
-                    if (count > 10)
-                    {
-                        AddSystemText("You can only generate up to 10 lorem ipsum messages at a time");
-                        return true;
-                    }
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        AddText("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
-                    }
-                    return true;
-                default:
-                    AddSystemText($"Unknown command: {command}");
-                    return true;
+                ConfigManager.Commands.ExecuteCommand(command, args);
+                return true;
+            }catch (Exception e)
+            {
+                Log.Error( e.Message );
+                return false;
             }
         }
 


### PR DESCRIPTION
I've expanded the command system to be more extensible.

This pr adds a `Game Controller` GameObject into the scene with a `Config Manager` script. The manager is used to store current configurations such as Commands for now. If there is an easier and more preferred way to do this, let me know. It's been done this way so that a "global" easily accessible List of commands can be accessed from anywhere.

The commands can be added to as such:
```csharp
// ConfigManager is a helper class that allows us to register commands and other things
ConfigManager ConfigManager;
protected override void OnStart()
{
    /// Get the ConfigManager from the scene
    ConfigManager = ConfigManagerHelper.GetConfigManager(Scene);
    if (ConfigManager is null)
    {
        Log.Error( "Config Manager not found" );
        return;
    }

    // Register the chat commands
    ConfigManager.Commands.RegisterCommand(new Command(
        name: "clear",
        description: "Clears the chat",
        permissionLevel: 0,
        commandFunction: (args) =>
        {
            Messages.Clear();
            NewSystemMessage("Chat has been cleared", true);
            return true;
        }
    ));
/// ....
```
The `ConfigManagerHelper.GetConfigManager(Scene);` will look for a specific component using its Guid in the Scene, which should be the `ConfigManager.cs` inside a `Game Controller` game object.

`permissionLevel` is unused for now. All functions take in args, which is a list of strings and all functions must return a bool. `True` if the function ran successfully. Returning true/false has no use for now, but later used to inform the user.

The command config and logic are in a new `Config` folder.