### PR TITLE
feat: Transparent HUD + Potentially fixed duplicated join/leave messages (need testing)

### DIFF
--- a/code/GameController/GameController.cs
+++ b/code/GameController/GameController.cs
@@ -21,6 +21,7 @@ public sealed class GameController : Component, Component.INetworkListener
 
 	protected override void OnStart()
 	{
+		Log.Info(GameObject.Id);
 		chat = Scene.Directory.FindByName( "Screen" )?.First()?.Components.Get<Chat>();
 		if ( chat == null ) Log.Error( "Chat component not found" );
 	}
@@ -32,7 +33,10 @@ public sealed class GameController : Component, Component.INetworkListener
 		try
 		{
 			Players.Add( new Player( player, connection ) );
-			chat?.NewSystemMessage( $"{connection.DisplayName} has joined the game." );
+			if ( Rpc.Caller.IsHost )
+			{
+				chat?.NewSystemMessage( $"{connection.DisplayName} has joined the game." );
+			}
 		}catch ( Exception e )
 		{
 			Log.Warning( e );
@@ -57,7 +61,10 @@ public sealed class GameController : Component, Component.INetworkListener
 
 			// Remove the player from the list
 			Players.Remove( playerToRemove );
-			chat?.NewSystemMessage( $"{connection.DisplayName} has left the game." );
+			if ( Rpc.Caller.IsHost )
+			{
+				chat?.NewSystemMessage( $"{connection.DisplayName} has left the game." );
+			}
 		} catch ( Exception e ) {
 			Log.Warning( e );
 		}

--- a/code/UI/BasicMenu.razor
+++ b/code/UI/BasicMenu.razor
@@ -9,16 +9,23 @@
     <!-- TODO this should be modularized -->
     <div class="main">
         <div class="side-bar">
-            <div class="buttoncontainer">
-                <button class="button @(IsJobsVisible ? "active" : "")" onclick="@DisplayJobs"> <i class="icon">work</i> Jobs </button>
-                <button class="button @(IsDarkWebVisible ? "active" : "")" onclick="@DisplayDarkWeb"> <i class="icon">store</i> Dark Web </button>
-                <button class="button @(IsPropsVisible ? "active" : "")" onclick="@DisplayProps"> <i class="icon">folder</i> Props </button> 
+            <div class="player-container">
+                <div class="name">@(Rpc.Caller.DisplayName.Truncate(13))</div>
+                <div class="sub">Salary:<span>$@(PlayerPrefab.Components.Get<PlayerStats>().SalaryAmmount.ToString("N0"))</span></div>
+                <div class="wallet">$@(PlayerPrefab.Components.Get<PlayerStats>().MoneyBase.ToString("N0"))</div
             </div>
-            <div class="buttoncontainer">
-                <button class="button @(IsAdminVisible ? "active" : "")" onclick="@DisplayAdmin"> <i class="icon">local_police</i> Admin Tools </button>
-                <button class="button @(IsInfoVisible ? "active" : "")" onclick="@DisplayInfo"> <i class="icon">info</i> Information </button>
-                <button class="button" onclick=@GitHubLink style="color:#4078c0;"> <i class="icon">web</i> @GitHub </button>
-                <button class="button" onclick=@DiscordLink style="color:#7289da;"> <i class="icon">discord</i> @Discord </button>
+            <div class="navigation">
+                <div class="buttoncontainer">
+                    <button class="button @(IsJobsVisible ? "active" : "")" onclick="@DisplayJobs"> <i class="icon">work</i> Jobs </button>
+                    <button class="button @(IsDarkWebVisible ? "active" : "")" onclick="@DisplayDarkWeb"> <i class="icon">store</i> Dark Web </button>
+                    <button class="button @(IsPropsVisible ? "active" : "")" onclick="@DisplayProps"> <i class="icon">folder</i> Props </button> 
+                </div>
+                <div class="buttoncontainer">
+                    <button class="button @(IsAdminVisible ? "active" : "")" onclick="@DisplayAdmin"> <i class="icon">local_police</i> Admin Tools </button>
+                    <button class="button @(IsInfoVisible ? "active" : "")" onclick="@DisplayInfo"> <i class="icon">info</i> Information </button>
+                    <button class="button" onclick=@GitHubLink style="color:#4078c0;"> <i class="icon">web</i> @GitHub </button>
+                    <button class="button" onclick=@DiscordLink style="color:#7289da;"> <i class="icon">discord</i> @Discord </button>
+                </div>
             </div>
         </div>
         <div class="main-container">

--- a/code/UI/BasicMenu.razor.scss
+++ b/code/UI/BasicMenu.razor.scss
@@ -5,7 +5,7 @@ BasicMenu {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: #24292f;
+	background-color: #24292ff4;
 	color: #c9c9c9;
 	//justify-content: center;
 	flex-direction: column;
@@ -53,6 +53,7 @@ BasicMenu {
 		flex-direction: column;
 		.name {
 			font-size: 35px;
+			margin-bottom: 5px;
 		}
 
 		.sub {
@@ -109,7 +110,7 @@ BasicMenu {
 		overflow-y: scroll;
 		overflow-x: visible;
 		justify-content: center;
-		background-color: #1b1b23;
+		background-color: #1b1b2318;
 		padding: 10px;
 		height: 100%;
 
@@ -123,7 +124,7 @@ BasicMenu {
 		}
 
 		.section {
-			background-color: #22222b;
+			background-color: #22222b5e;
 			border-radius: 15px 15px 0 0;
 			width: 100%;
 			display: flex;

--- a/code/UI/BasicMenu.razor.scss
+++ b/code/UI/BasicMenu.razor.scss
@@ -37,9 +37,33 @@ BasicMenu {
 
 	.side-bar {
 		flex-direction: column;
-		justify-content: space-between;
 		width: 20vw;
 		height: 100%;
+	}
+
+	.navigation {
+		flex-direction: column;
+		justify-content: space-between;
+		height: 100%;
+	}
+
+	.player-container {
+		padding: 20px;
+		height: 20%;
+		flex-direction: column;
+		.name {
+			font-size: 35px;
+		}
+
+		.sub {
+			font-size: 25px;
+			gap: 3px;
+		};
+
+		.wallet {
+			font-size: 25px;
+			color: #556B2F;
+		}
 	}
 	
 	.buttoncontainer {

--- a/code/UI/Chat.razor
+++ b/code/UI/Chat.razor
@@ -20,6 +20,10 @@
             {
                 <div class="chat_entry">
                     <div class="timestamp">@entry.timestamp</div>
+                    @if (DevSteamIDs.Contains(entry.steamid))
+                    {
+                        <div class="user-group">DEV</div>
+                    }
                     @if (entry.steamid > 0)
                     {
                         <div class="avatar" style="background-image: url( avatar:@entry.steamid )"></div>
@@ -73,6 +77,14 @@
 
 @code
 {
+
+
+    // TODO temporary clout
+    private static ulong[] DevSteamIDs = new ulong[] {
+		76561198844028104, // Sousou
+		76561198137204749, // QueenPM
+	};
+
     TextEntry InputBox;
     bool ChatOpen = false;
     public record Entry(ulong steamid, string author, string message, RealTimeSince timeSinceAdded)

--- a/code/UI/Chat.razor
+++ b/code/UI/Chat.razor
@@ -230,6 +230,18 @@
         SendMessage( message, true );
     }
 
+    @* void INetworkListener.OnDisconnected( Connection channel )
+	{
+        if ( IsProxy ) return;
+		NewSystemMessage( $"{channel.DisplayName} has left the game." );
+	}
+
+    void INetworkListener.OnConnected( Connection channel )
+	{
+        if ( IsProxy ) return;
+		NewSystemMessage( $"{channel.DisplayName} has joined the game." );
+	} *@
+
     public void ClearChat()
     {
         Messages.Clear();

--- a/code/UI/Chat.razor
+++ b/code/UI/Chat.razor
@@ -218,20 +218,6 @@
         SendMessage( message, true );
     }
 
-	void Component.INetworkListener.OnConnected( Connection channel )
-	{
-		if ( IsProxy ) return;
-
-		NewSystemMessage( $"{channel.DisplayName} has joined the game" );
-	}
-
-	void Component.INetworkListener.OnDisconnected( Connection channel )
-	{
-		if ( IsProxy ) return;
-
-		NewSystemMessage( $"{channel.DisplayName} has left the game" );
-	}
-
     public void ClearChat()
     {
         Messages.Clear();

--- a/code/UI/Chat.razor.scss
+++ b/code/UI/Chat.razor.scss
@@ -2,7 +2,8 @@ Chat {
 	position: absolute;
 	bottom: 300px;
 	left: 100px;
-	width: 600px;
+	width: 40vw;
+	height: 40vh;
 	justify-content: center;
 	font-weight: bold;
 	border-radius: 20px;
@@ -44,9 +45,19 @@ Chat {
 				width: 70px;
 			}
 
+			.user-group {
+				width: 40px;
+				padding: 0;
+				margin: 0;
+				display: flex;
+				text-align: center;
+				justify-content: center;
+				color: rgb(231, 197, 84);
+			}
+
 			.avatar {
-				width: 45px;
-				height: 30px;
+				width: 25px;
+				height: 25px;
 				margin-left: 5px;
 				margin-right: 5px;
 				background-position: center;
@@ -62,6 +73,9 @@ Chat {
 			.message {
 				color: #fff;
 				width: 100%;
+				flex-basis: 50%;
+				flex-grow: 1;
+				flex-shrink: 1;
 			}
 		}
 	}

--- a/code/UI/Chat.razor.scss
+++ b/code/UI/Chat.razor.scss
@@ -3,7 +3,7 @@ Chat {
 	bottom: 300px;
 	left: 100px;
 	width: 40vw;
-	height: 40vh;
+	height: auto;
 	justify-content: center;
 	font-weight: bold;
 	border-radius: 20px;

--- a/code/UI/PlayerHUD.razor
+++ b/code/UI/PlayerHUD.razor
@@ -6,15 +6,17 @@
     <div style="font-color:white; font-size: 25px; margin-top: 20px; margin-left: 20px">@MyStringValue</div>
 
     <div class="player-card">
-        <div class="title">
-            <div class="name">@Rpc.Caller.DisplayName.Truncate(13)</div>
-            <div class="center">
-                <div class="job">@MyStringValue3</div>
+        <div class="player-details-container">
+            <div class="container">
+                <div class="name">@Rpc.Caller.DisplayName.Truncate(13)</div>
+                <div class="wallet">
+                    <div class="label">Wallet</div>
+                </div>
             </div>
-        </div>
-        <div class="wallet">
-            <div class="label">Wallet</div>
-            <div class="money">$ @(PlayerPrefab.Components.Get<PlayerStats>().MoneyBase.ToString("N0"))</div>
+            <div class="container">
+                <div class="job">@MyStringValue3</div>
+                <div class="money">$ @(PlayerPrefab.Components.Get<PlayerStats>().MoneyBase.ToString("N0"))</div>
+            </div>
         </div>
         <div class="bars">
             <div class="bar">

--- a/code/UI/PlayerHUD.razor.scss
+++ b/code/UI/PlayerHUD.razor.scss
@@ -9,8 +9,8 @@ PlayerHUD {
 		display: flex;
 		flex-direction: column;
 		width: auto;
-		height: 10rem;
-		margin: 1.5rem;
+		height: auto;
+		margin: 1rem;
 		font-family: 'Times New Roman', serif;
 		padding: 10px;
 
@@ -20,7 +20,7 @@ PlayerHUD {
 			.container {
 				display: flex;
 				flex-direction: column;
-				height: 5rem;
+				height: auto;
 				justify-content: space-between;
 
 				.center {

--- a/code/UI/PlayerHUD.razor.scss
+++ b/code/UI/PlayerHUD.razor.scss
@@ -68,7 +68,7 @@ PlayerHUD {
 
 		.bar {
 			width: 100%;
-			height: 1rem;
+			height: 2.5vh;
 			background-color: #ccc;
 			position: relative;
 		}

--- a/code/UI/PlayerHUD.razor.scss
+++ b/code/UI/PlayerHUD.razor.scss
@@ -3,8 +3,9 @@ PlayerHUD {
 		position: absolute;
 		left: 0;
 		bottom: 0;
-		background-color: #1e1e27ba;
+		// background-color: #1e1e27ba;
 		color: white;
+		text-shadow: 2px 2px 4px #000000;
 		display: flex;
 		flex-direction: column;
 		width: 20vw;

--- a/code/UI/PlayerHUD.razor.scss
+++ b/code/UI/PlayerHUD.razor.scss
@@ -8,50 +8,53 @@ PlayerHUD {
 		text-shadow: 2px 2px 4px #000000;
 		display: flex;
 		flex-direction: column;
-		width: 20vw;
-		height: auto;
-		margin: 0.5rem;
+		width: auto;
+		height: 10rem;
+		margin: 1.5rem;
 		font-family: 'Times New Roman', serif;
 		padding: 10px;
 
-		.title {
-			display: flex;
-			flex-direction: row;
-			justify-content: space-between;
-			margin-bottom: 10px;
-			gap: 10px;
-
-			.name {
-				font-size: 35px;
-			}
-
-			.center {
+		.player-details-container {
+			width: 100%;
+			gap: 2rem;
+			.container {
 				display: flex;
 				flex-direction: column;
-				justify-content: center;
-			}
+				height: 5rem;
+				justify-content: space-between;
 
-			.job {
-				font-size: 25px;
-			}
-		}
+				.center {
+					flex-direction: column;
+					justify-content: center;
+					height: 100%;
+				}
 
+				.name {
+					font-size: 35px;
+				}
 
-		.wallet {
-			display: flex;
-			flex-direction: row;
-			font-size: 25px;
-			width: 100%;
-			justify-content: space-between;
+				.job {
+					font-size: 25px;
+					align-self: flex-end;
+				}
 
-			.label {
-				margin-right: 100px
-			}
+				.money {
+					color: lawngreen;
+					margin-left: 10px;
+					align-self: flex-end;
+					font-size: 25px;
+				}
 
-			.money {
-				color: lawngreen;
-				margin-left: 10px;
-				align-self: flex-end;
+				.wallet {
+					display: flex;
+					flex-direction: row;
+					font-size: 25px;
+					width: 100%;
+		
+					.label {
+						margin-right: 100px
+					}
+				}
 			}
 		}
 
@@ -60,11 +63,12 @@ PlayerHUD {
 			flex-direction: column;
 			margin-top: 10px;
 			gap: 10px;
+			height: auto;
 		}
 
 		.bar {
 			width: 100%;
-			height: 1vh;
+			height: 1rem;
 			background-color: #ccc;
 			position: relative;
 		}


### PR DESCRIPTION
### Features
- Adjusted TAB to be transparent for better visibility when spawning in props.
- Added Player details into the TAB Menu for better visibility of your wallet whilst purchasing entities.
- Removed the background from HUD so there are no clashing boxes between the semi-transparent TAB and semi-transparent HUD.
- Potentially fixed the Chat Join/Leave messages being duplicated per player by moving the logic from Chat to GameController and checking for Host, so it only sends messages once :) (hopefully)