### PR TITLE
fix: Door broadcast

### DIFF
--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -66,7 +66,7 @@ namespace Entity.Interactable.Door
 			{
 				return;
 			}
-			UnlockDoor();
+			IsUnlocked = true;
 			UpdateDoorOwner();
 		}
 

--- a/code/GameSystems/Player/Stats.cs
+++ b/code/GameSystems/Player/Stats.cs
@@ -11,7 +11,7 @@ namespace GameSystems.Player
 	{
 		// DOORS
 
-		[Property] public List<GameObject> Doors { get; private set; } = new List<GameObject>();
+		[Sync][Property] public List<GameObject> Doors { get; private set; } = new List<GameObject>();
 
 
 		// BASE PLAYER PROPERTYS
@@ -126,8 +126,6 @@ namespace GameSystems.Player
 		}
 
 		// DOOR LOGIC. Helps keep track of owned doors.
-
-		[Broadcast]
 		public void PurchaseDoor(float price, GameObject door)
 		{
 			Log.Info( $"Purchasing the door: {door.Id}" );
@@ -147,8 +145,8 @@ namespace GameSystems.Player
 			if (RemoveMoney(price))
 			{
 				Doors.Add(door);
-				SendMessage("Door has been purchased.");
 				doorLogic.UpdateDoorOwner( GameObject, this);
+				SendMessage("Door has been purchased.");
 				Sound.Play( "audio/notification.sound" );
 				return;
 			}
@@ -157,10 +155,8 @@ namespace GameSystems.Player
 				SendMessage("Can't afford this door.");
 				return;
 			}
-
 		}
 
-		[Broadcast]
 		public void SellDoor(GameObject door)
 		{
 			Log.Info($"Selling door: {door.Id}");
@@ -200,7 +196,6 @@ namespace GameSystems.Player
 		// TODO this would need to go to its own class. PlayerController or some shit
 		public void SendMessage(string message)
 		{
-			if ( Rpc.Caller.IsHost ) return;
 			using (Rpc.FilterInclude(c => c.Id == Rpc.CallerId))
 			{
 				chat?.NewSystemMessage(message);


### PR DESCRIPTION
Made the list of doors owned by the player in `Stats.cs` to be Sync, so that the GameController is aware of door ownership from a player's perspective.

Removed Broadcast decorator from Buying and Selling functions inside of `Stats.cs`, as they do not need to be ran across all clients as long as the properties are Sync.