### PR TITLE
refactor: Door messages are now Notifications

### DIFF
--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -5,16 +5,12 @@ namespace Entity.Interactable.Door
 {
 	public sealed class DoorLogic : BaseEntity, Component.INetworkListener
 	{
-		[Property]
-		public GameObject Door { get; set; }
-		[Property, Sync]
-		public bool IsUnlocked { get; set; } = true;
-		[Property, Sync]
-		public bool IsOpen { get; set; } = false;
+		[Property] public GameObject Door { get; set; }
+		[Property, Sync] public bool IsUnlocked { get; set; } = true;
+		[Property, Sync] public bool IsOpen { get; set; } = false;
 		[Property, Sync] public Stats OwnerStats { get; set; }
 
-		[Property, Sync]
-		public int Price { get; set; } = 100;
+		[Property, Sync] public int Price { get; set; } = 100;
 
 
 		public override void InteractUse( SceneTraceResult tr, GameObject player )

--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -60,6 +60,7 @@ namespace Entity.Interactable.Door
 			OwnerStats = playerStats;
 		}
 
+		[Broadcast]
 		public void SellDoor() //This Function does no longer removes the Door in Player.Stats or checks if it's done
 		{
 			if ( Owner == null )
@@ -83,19 +84,17 @@ namespace Entity.Interactable.Door
 			Sound.Play( "audio/door.sound", Door.Transform.World.Position );
 		}
 
-		[Broadcast]
 		private void LockDoor()
 		{
 			IsUnlocked = false;
-			OwnerStats?.SendMessage( "Door has been locked." );
+			OwnerStats?.Notify(PlayerHUD.NotificationType.Info, "Door has been locked." );
 			Sound.Play( "audio/lock.sound", Door.Transform.World.Position );
 		}
 
-		[Broadcast]
 		private void UnlockDoor()
 		{
 			IsUnlocked = true;
-			OwnerStats?.SendMessage( "Door has been unlocked." );
+			OwnerStats?.Notify(PlayerHUD.NotificationType.Info, "Door has been unlocked." );
 			Sound.Play( "audio/lock.sound", Door.Transform.World.Position );
 		}
 		private void KnockOnDoor()

--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -12,7 +12,6 @@ namespace Entity.Interactable.Door
 
 		[Property, Sync] public int Price { get; set; } = 100;
 
-
 		public override void InteractUse( SceneTraceResult tr, GameObject player )
 		{
 			// Dont interact with the door if it is locked
@@ -56,7 +55,6 @@ namespace Entity.Interactable.Door
 			OwnerStats = playerStats;
 		}
 
-		[Broadcast]
 		public void SellDoor() //This Function does no longer removes the Door in Player.Stats or checks if it's done
 		{
 			if ( Owner == null )

--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -11,7 +11,7 @@ namespace Entity.Interactable.Door
 		public bool IsUnlocked { get; set; } = true;
 		[Property, Sync]
 		public bool IsOpen { get; set; } = false;
-		public Stats OwnerStats { get; set; }
+		[Property, Sync] public Stats OwnerStats { get; set; }
 
 		[Property, Sync]
 		public int Price { get; set; } = 100;

--- a/code/Entity/Interactable/Door/DoorLogic.cs
+++ b/code/Entity/Interactable/Door/DoorLogic.cs
@@ -26,13 +26,13 @@ namespace Entity.Interactable.Door
 			if ( Owner == null )
 			{
 				var playerStats = player.Components.Get<Stats>();
-				playerStats.PurchaseDoor(Price ,this.Door);
+				playerStats.PurchaseDoor( Price, this.Door );
 			}
 			else
 			{
 				if ( Owner.GameObject.Id == player.Id )
 				{
-					OwnerStats.SellDoor(this.Door);
+					OwnerStats.SellDoor( this.Door );
 				}
 			}
 		}
@@ -40,13 +40,13 @@ namespace Entity.Interactable.Door
 		public override void InteractAttack1( SceneTraceResult tr, GameObject player )
 		{
 			// TODO The user should have a "keys" weapon select to do the following interactions to avoid input conflicts
-			if (player.Id == Owner?.GameObject.Id ) { LockDoor(); } else { KnockOnDoor(); }
+			if ( player.Id == Owner?.GameObject.Id ) { LockDoor(); } else { KnockOnDoor(); }
 		}
 
 		public override void InteractAttack2( SceneTraceResult tr, GameObject player )
 		{
 			// TODO The user should have a "keys" weapon select to do the following interactions to avoid input conflicts
-			if (player.Id == Owner?.GameObject.Id) { UnlockDoor(); } else { KnockOnDoor(); }
+			if ( player.Id == Owner?.GameObject.Id ) { UnlockDoor(); } else { KnockOnDoor(); }
 		}
 
 		[Broadcast]
@@ -83,14 +83,14 @@ namespace Entity.Interactable.Door
 		private void LockDoor()
 		{
 			IsUnlocked = false;
-			OwnerStats?.Notify(PlayerHUD.NotificationType.Info, "Door has been locked." );
+			OwnerStats?.Notify( PlayerHUD.NotificationType.Info, "Door has been locked." );
 			Sound.Play( "audio/lock.sound", Door.Transform.World.Position );
 		}
 
 		private void UnlockDoor()
 		{
 			IsUnlocked = true;
-			OwnerStats?.Notify(PlayerHUD.NotificationType.Info, "Door has been unlocked." );
+			OwnerStats?.Notify( PlayerHUD.NotificationType.Info, "Door has been unlocked." );
 			Sound.Play( "audio/lock.sound", Door.Transform.World.Position );
 		}
 		private void KnockOnDoor()


### PR DESCRIPTION
- Changed door state updates to notifications
- Added helper function `Notify` inside of `Stats.cs`, part of Player.
- Changed the filtering of `SendMessage` and `Notify` to target `GameObject.Network.OwnerId`.

## Known issues
- Purchased doors do not appear purchased by joining players. They are able to overwrite the purchase.