### PR TITLE
refactor: Moved NetworkHelper to our codebase

### DIFF
--- a/Assets/scenes/minimal.scene
+++ b/Assets/scenes/minimal.scene
@@ -97,6 +97,16 @@
             "_type": "gameobject",
             "prefab": "prefab/money.prefab"
           }
+        },
+        {
+          "__type": "GameSystems.NetworkController",
+          "__guid": "ab7ef311-9b45-4efe-8cee-227ab2603134",
+          "PlayerPrefab": {
+            "_type": "gameobject",
+            "prefab": "prefab/player.prefab"
+          },
+          "SpawnPoints": [],
+          "StartServer": true
         }
       ]
     },
@@ -118,26 +128,6 @@
         {
           "__type": "Chat",
           "__guid": "d44a2652-d727-454b-afb0-6637c4caff57"
-        }
-      ]
-    },
-    {
-      "__guid": "7a63f673-6998-43a4-80de-532550116c66",
-      "Flags": 0,
-      "Name": "Network Manager",
-      "Position": "0,0,136.2419",
-      "Enabled": true,
-      "NetworkOrphaned": 1,
-      "Components": [
-        {
-          "__type": "Sandbox.NetworkHelper",
-          "__guid": "7a015147-d27b-44b1-a3a5-81d364b2e76b",
-          "PlayerPrefab": {
-            "_type": "gameobject",
-            "prefab": "prefab/player.prefab"
-          },
-          "SpawnPoints": [],
-          "StartServer": true
         }
       ]
     },

--- a/code/GameSystems/NetworkController.cs
+++ b/code/GameSystems/NetworkController.cs
@@ -55,6 +55,11 @@ public sealed class NetworkController : Component, Component.INetworkListener
 
 		// Spawn this object and make the client the owner
 		var player = PlayerPrefab.Clone( startLocation, name: $"Player - {channel.DisplayName}" );
+    try{
+      GameController.Instance.AddPlayer( player, channel );
+    }catch (Exception e){
+      Log.Error( $"Failed to add player to list. {e}" );
+    }
 		player.NetworkSpawn( channel );
 	}
 

--- a/code/GameSystems/NetworkController.cs
+++ b/code/GameSystems/NetworkController.cs
@@ -1,0 +1,88 @@
+using Sandbox.Network;
+using System;
+using System.Threading.Tasks;
+
+namespace GameSystems;
+
+[Title( "Network Controller" )]
+[Category( "Networking" )]
+[Icon( "electrical_services" )]
+public sealed class NetworkController : Component, Component.INetworkListener
+{
+	/// <summary>
+	/// Create a server (if we're not joining one)
+	/// </summary>
+	[Property] public bool StartServer { get; set; } = true;
+
+	/// <summary>
+	/// The prefab to spawn for the player to control.
+	/// </summary>
+	[Property] public GameObject PlayerPrefab { get; set; }
+
+	/// <summary>
+	/// A list of points to choose from randomly to spawn the player in. If not set, we'll spawn at the
+	/// location of the NetworkHelper object.
+	/// </summary>
+	[Property] public List<GameObject> SpawnPoints { get; set; }
+
+	protected override async Task OnLoad()
+	{
+		if ( Scene.IsEditor )
+			return;
+
+		if ( StartServer && !GameNetworkSystem.IsActive )
+		{
+			LoadingScreen.Title = "Creating Lobby";
+			await Task.DelayRealtimeSeconds( 0.1f );
+			GameNetworkSystem.CreateLobby();
+		}
+	}
+
+	/// <summary>
+	/// A client is fully connected to the server. This is called on the host.
+	/// </summary>
+	public void OnActive( Connection channel )
+	{
+		Log.Info( $"Player '{channel.DisplayName}' has joined the game" );
+
+		if ( PlayerPrefab is null )
+			return;
+
+		//
+		// Find a spawn location for this player
+		//
+		var startLocation = FindSpawnLocation().WithScale( 1 );
+
+		// Spawn this object and make the client the owner
+		var player = PlayerPrefab.Clone( startLocation, name: $"Player - {channel.DisplayName}" );
+		player.NetworkSpawn( channel );
+	}
+
+	/// <summary>
+	/// Find the most appropriate place to respawn
+	/// </summary>
+	Transform FindSpawnLocation()
+	{
+		//
+		// If they have spawn point set then use those
+		//
+		if ( SpawnPoints is not null && SpawnPoints.Count > 0 )
+		{
+			return Random.Shared.FromList( SpawnPoints, default ).Transform.World;
+		}
+
+		//
+		// If we have any SpawnPoint components in the scene, then use those
+		//
+		var spawnPoints = Scene.GetAllComponents<SpawnPoint>().ToArray();
+		if ( spawnPoints.Length > 0 )
+		{
+			return Random.Shared.FromArray( spawnPoints ).Transform.World;
+		}
+
+		//
+		// Failing that, spawn where we are
+		//
+		return Transform.World;
+	}
+}

--- a/code/GameSystems/Player/Stats.cs
+++ b/code/GameSystems/Player/Stats.cs
@@ -47,7 +47,6 @@ namespace GameSystems.Player
 				controller = GameController.Instance;
 
 				if ( controller == null ) Log.Error( "Game Controller component not found" );
-				controller.AddPlayer( GameObject, GameObject.Network.OwnerConnection );
 				Job = JobSystem.GetDefault();
 			}
 			catch ( Exception e )


### PR DESCRIPTION
Moved the `NetworkHelper` to our codebase by making a copy of it, and named it `NetworkController.cs`.

The component is now part of the Game Controller game object in the scene.

Moved adding the player to the player list inside of game controller from the `OnStart` function of `Stats.cs` into the `NetworkController.cs`